### PR TITLE
Check for undefined before calling deepcopy, otherwise it fails.

### DIFF
--- a/lib/wurfl.js
+++ b/lib/wurfl.js
@@ -15,7 +15,7 @@ function get(userAgent, deepcopy) {
 
   var device = userAgents[userAgent];
 
-  if(deepcopy) {
+  if(deepcopy && device !== undefined) {
     device = device.deepCopy();
   }
 


### PR DESCRIPTION
---

Exception: TypeError: Cannot call method 'deepCopy' of undefined
TypeError: Cannot call method 'deepCopy' of undefined
    at Object.get (/var/www/phadserver/node_modules/wurfl/lib/wurfl.js:19:21)
