### PR TITLE
Updated node-expat to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"test": "node test/test.js"
 	},
 	"dependencies": {
-		"node-expat": "1.4.1",
+		"node-expat": "2.0.0",
 		"backgrounder": "0.2.7"
 	},
 	"homepage": "https://github.com/touchads/node-wurfl-api",


### PR DESCRIPTION
Changed the dependency of node-expat to 2.0.0 so it doesn't break when installing on node > 0.8 (it was failing due to the node-waf -> node-gyp migration)
