### PR TITLE
Could we update the NPM repo to point to a new version with new node-expat deps?

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "wurfl",
 	"author": "Jacob Wright <jacwright@gmail.com> (jacwright.com)",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"main": "./lib/wurfl",
 	"description": "NodeJS library for loading Wireless Universal Resource File (wurfl) xml file efficiently into memory for use in applications that need to lookup mobile device capabilities by their user agent.",
 	"scripts": {


### PR DESCRIPTION
Update version num so that NPM repo reflects new version of node-expat for use on node v.8+.

In our deployment environment, we generally use npm install to build out the project dependencies, but right now i need to use a fork of the codebase post-panela's commit in order to run node-wurfl-api on node v0.8+
